### PR TITLE
Force percent-encoding of fragment

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -6,6 +6,7 @@ const optionName = isFirefox ? 'allowScriptsToClose' : 'setSelfAsOpener'
 const quote = text => '“' + text + '”'
 const buildText = (title, selection) => quote(selection) + ' / ' + title
 const buildUrl = (base, params) => base + '?' + new URLSearchParams(params)
+const encodeFragment = fragment => '#' + encodeURIComponent(fragment.slice(1)).replace(/[\.!~\*'\(\)]/g, c => '%' + c.charCodeAt(0).toString(16))
 
 const baseUrl = 'https://twitter.com/intent/tweet'
 const code = 'window.getSelection().toString()'
@@ -15,8 +16,9 @@ const height = 420
 chrome.browserAction.onClicked.addListener(({ url, title }) => {
   chrome.tabs.executeScript({ code }, ([ selection ] = []) => {
     const text = selection ? buildText(title, selection) : title
+    const urlEncodedFragment = url.replace(/#.*$/, fragment => encodeFragment(decodeURIComponent(fragment)))
     chrome.windows.create({
-      url: buildUrl(baseUrl, { url, text }),
+      url: buildUrl(baseUrl, { url: urlEncodedFragment, text }),
       left: Math.round((screen.width - width) / 2),
       top: Math.round((screen.height - height) / 2),
       width,


### PR DESCRIPTION
### Summary

`chrome.browserAction.onClicked.addListener(listener)`が`listener`に渡すオブジェクトのurlプロパティでは、フラグメントのパーセントエンコーディングが不十分なため、Twitterは[このようなURL](https://www.scala-lang.org/api/current/scala/Int.html#-%3E[B](y:B):(A,B))をURLとして認識しません。

以下は、https://github.com/foooomio/tweet-button-webext/commit/83eb8e372c37d08f01bec1ee12899b9b7a4f85c5 を用いてツイートした例です。
<blockquote class="twitter-tweet"><p lang="it" dir="ltr">Scala Standard Library 2.13.5 - <a href="https://t.co/tFacmq0atI">https://t.co/tFacmq0atI</a> <a href="https://t.co/OBe7MPNPFC">https://t.co/OBe7MPNPFC</a>](y:B):(A,B)</p>&mdash; ypc2e55orj (@ypc2e55orj) <a href="https://twitter.com/ypc2e55orj/status/1369640762359488512?ref_src=twsrc%5Etfw">March 10, 2021</a></blockquote>

このpull requestでは、上記のようなURLでもTwitterがURLとして認識するように改変しています。

`encodeURIComponent()`のみではいくつかの文字がエンコードされないため、それらは置換しています。

<blockquote class="twitter-tweet"><p lang="it" dir="ltr">Scala Standard Library 2.13.5 - <a href="https://t.co/tFacmq0atI">https://t.co/tFacmq0atI</a> <a href="https://t.co/mSroAGseVT">https://t.co/mSroAGseVT</a></p>&mdash; ypc2e55orj (@ypc2e55orj) <a href="https://twitter.com/ypc2e55orj/status/1369640781049257989?ref_src=twsrc%5Etfw">March 10, 2021</a></blockquote>

### Reference
https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent